### PR TITLE
fetchByIdsAsync does no longer return callback

### DIFF
--- a/database.mjs
+++ b/database.mjs
@@ -349,7 +349,7 @@ export default class ConnectionInfo {
 
             repo.findByIds(idRef)
                 .then(res => {
-                    if (res.length <= 0) return callback(undefined);
+                    if (res.length <= 0) return resolve(undefined);
                     return resolve(res);
                 })
                 .catch(err => {


### PR DESCRIPTION
Since _callback_ is not defined in method, _fetchByIdsAsync_ does now resolve the promise if res.length <= 0. 